### PR TITLE
Conditionally add eslint module in buildModule

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -31,13 +31,13 @@ export default {
 
   // Modules for dev and build (recommended): https://go.nuxtjs.dev/config-modules
   buildModules: [
-    // https://go.nuxtjs.dev/eslint
-    '@nuxtjs/eslint-module',
     // https://go.nuxtjs.dev/tailwindcss
     '@nuxtjs/tailwindcss',
     '@nuxtjs/axios',
     '@nuxtjs/moment',
-  ],
+  ].concat(
+    process.env.NODE_ENV !== 'production' ? '@nuxtjs/eslint-module' : []
+  ),
 
   axios: {
     proxy: true,


### PR DESCRIPTION
#### Summary

Fix deployment issue, where eslint-module is not being found when running npm run generate in Netlify deployment.

#### Checklist

- [X] Have read the Contributing Guidelines and Code of Conduct
- [X] Used Conventional Commit messages
- [X] Created new test cases for new components/pages, and it passes. (if applicable)
- [X] Existing test cases are all passing.

#### Tests
![image](https://user-images.githubusercontent.com/31644925/120595860-9da53600-c475-11eb-8de1-089d2cc04dca.png)



#### Additional Information

N/A